### PR TITLE
Add auto_advance_setup field to profile

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -28,6 +28,7 @@ type Profile struct {
 	AwaitDeviceConfigured bool     `json:"await_device_configured,omitempty"`
 	IsMDMRemovable        bool     `json:"is_mdm_removable"`
 	SupportPhoneNumber    string   `json:"support_phone_number,omitempty"`
+	AutoAdvanceSetup      bool     `json:"auto_advance_setup,omitempty"`
 	SupportEmailAddress   string   `json:"support_email_address,omitempty"`
 	OrgMagic              string   `json:"org_magic"`
 	AnchorCerts           []string `json:"anchor_certs,omitempty"`


### PR DESCRIPTION
Docs say its for:

> Optional. Boolean. If set to true, the device will tell tvOS Setup Assistant to automatically advance though its screens. Default is false. This key is valid in X-Server-Protocol-Version 2 and later.